### PR TITLE
TUT-250 [FIX] URL params full path

### DIFF
--- a/app/client/containers/EndpointDoc/EndpointDoc.js
+++ b/app/client/containers/EndpointDoc/EndpointDoc.js
@@ -188,8 +188,8 @@ class EndpointDoc extends React.Component {
   }
 
   getFullLink = () => {
-    const { projectUrl, group, endpoint } = this.props;
-    return getFullLink(projectUrl, endpoint, group);
+    const { projectUrl, endpoint } = this.props;
+    return getFullLink(projectUrl, endpoint);
   }
 
   render() {

--- a/app/client/containers/RequestParam/RequestParam.js
+++ b/app/client/containers/RequestParam/RequestParam.js
@@ -132,8 +132,8 @@ class RequestParam extends React.Component {
 
 
   getFullLink = () => {
-    const { projectUrl, group, endpoint } = this.props;
-    return getFullLink(projectUrl, endpoint, group);
+    const { projectUrl, endpoint } = this.props;
+    return getFullLink(projectUrl, endpoint);
   }
 
   onTypeChange = (id) => {

--- a/app/client/containers/ResponseParam/ResponseParam.js
+++ b/app/client/containers/ResponseParam/ResponseParam.js
@@ -151,8 +151,8 @@ class ResponseParam extends React.Component {
 
 
   getFullLink = () => {
-    const { projectUrl, group, endpoint } = this.props;
-    return getFullLink(projectUrl, endpoint, group);
+    const { projectUrl, endpoint } = this.props;
+    return getFullLink(projectUrl, endpoint);
   }
 
   onTypeChange = (id) => {

--- a/app/client/services/helpers.js
+++ b/app/client/services/helpers.js
@@ -1,5 +1,5 @@
-export function getFullLink(domain, endpoint, group) {
-  const basePath = `${domain}${group.fullPath}`;
+export function getFullLink(domain, endpoint) {
+  const basePath = `${domain}${endpoint.url}`;
 
   if (endpoint.params) {
     const mainParam = endpoint.params.find(p => p.main);


### PR DESCRIPTION
# What

This PR fixes the way we display full path. It used to look like this:
<img width="449" alt="zrzut ekranu 2017-04-20 o 12 37 26" src="https://cloud.githubusercontent.com/assets/1729299/25226684/211204e4-25c6-11e7-9e53-5d94b9a43674.png">

But now it looks like this:
<img width="584" alt="zrzut ekranu 2017-04-20 o 12 37 44" src="https://cloud.githubusercontent.com/assets/1729299/25226701/2be9e90e-25c6-11e7-916d-29ed0ba587a8.png">

## Context
We used to hold information about a path in a group. This was based on misunderstanding that Group should indicate only endpoints with similar URLs. Truth is that only endpoint holds information about URL, so I've had to remove group from URL builder

