### PR TITLE
TUT-247 [FIX] Display http_status_code for responses

### DIFF
--- a/app/client/containers/EndpointDoc/EndpointDoc.js
+++ b/app/client/containers/EndpointDoc/EndpointDoc.js
@@ -151,7 +151,7 @@ class EndpointDoc extends React.Component {
       <Row
         key={key}
         data={[
-          <div>Status <span className={styles.responseParam}>{`${param.status_code ? param.status_code : ''}`}</span></div>,
+          <div>Status <span className={styles.responseParam}>{`${param.http_status_code ? param.http_status_code : ''}`}</span></div>,
         ]}
         actions={[
           <IconButton icon={<Icon name="pencil" size="lg" />} onClick={this.editResponse(param.id)} />,


### PR DESCRIPTION
# What

We used to name one param in response differently but for more clarity backend renamed it to "http_status_code". This required change of status code here

<img width="362" alt="zrzut ekranu 2017-04-20 o 12 54 31" src="https://cloud.githubusercontent.com/assets/1729299/25227362/8462af42-25c8-11e7-826c-1f51cf0cba83.png">

## NOTE
Backend will have to remove duplicated responses and responses without http status codes