### PR TITLE
Disable documentation link when no endpoints were recorded

### DIFF
--- a/app/client/components/NavigationLink/NavigationLink.css
+++ b/app/client/components/NavigationLink/NavigationLink.css
@@ -26,3 +26,9 @@
   color: #6fb3e3;
   margin-right: 5px;
 }
+
+.disabled {
+  opacity: 0.4;
+  cursor: normal;
+  pointer-events: none;
+}

--- a/app/client/components/NavigationLink/NavigationLink.js
+++ b/app/client/components/NavigationLink/NavigationLink.js
@@ -14,14 +14,15 @@ class NavigationLink extends React.Component {
     index: React.PropTypes.bool,
     icon: React.PropTypes.node,
     projectSlug: React.PropTypes.string,
+    disabled: React.PropTypes.bool,
   }
 
   render() {
-    const { url = '/', text, index, icon, projectSlug } = this.props;
-
+    const { url = '/', text, index, icon, projectSlug, disabled } = this.props;
+    const classNames = [styles.navigationLink, (disabled && styles.disabled)];
     const props = {
       to: `/${projectSlug}${url}`,
-      className: styles.navigationLink,
+      className: classNames.join(' '),
       activeClassName: styles.navigationLinkActive,
     };
 

--- a/app/client/containers/AppLayout.js
+++ b/app/client/containers/AppLayout.js
@@ -19,6 +19,7 @@ import Modals from 'modals/Modals';
   projects: store.projects.projectList,
   activeProject: store.projects.activeProject,
   username: store.session.user && store.session.user.email,
+  endpointsCount: store.endpoints.length,
 }))
 
 class AppLayout extends React.Component {
@@ -49,6 +50,7 @@ class AppLayout extends React.Component {
     projects: React.PropTypes.array,
     activeProject: React.PropTypes.object,
     username: React.PropTypes.string,
+    endpointsCount: React.PropTypes.number,
   }
 
   switchProject = (id) => {
@@ -60,7 +62,7 @@ class AppLayout extends React.Component {
   }
 
   render() {
-    const { projects, activeProject, username } = this.props;
+    const { projects, activeProject, username, endpointsCount } = this.props;
 
     return (
       <div className={styles.appLayout}>
@@ -77,7 +79,7 @@ class AppLayout extends React.Component {
                 />
               )}
               <NavLink url="/editor" text="Editor" icon={<Icon name="edit" />} />
-              <NavLink url="/documentation" index={!this.props.params.group_id} text="Documentation" icon={<CustomIcon name="documentation" size="sm" />} />
+              <NavLink url="/documentation" index={!this.props.params.group_id} text="Documentation" icon={<CustomIcon name="documentation" size="sm" />} disabled={endpointsCount === 0} />
               <NavLink url="/settings" text="Settings" icon={<CustomIcon name="settings" size="sm" />} />
             </div>
             <div className={styles.right}>

--- a/app/client/containers/DocumentationViewer/DocumentationViewer.js
+++ b/app/client/containers/DocumentationViewer/DocumentationViewer.js
@@ -95,12 +95,6 @@ class DocumentationViewer extends React.Component {
       <div className={styles.container}>
         { this.props.isFetching && <LoadingIndicator fixed /> }
         <Sidebar>
-          <TextInput
-            value={this.state.search}
-            placeholder="Search"
-            iconRight={this.renderIcon()}
-            onChange={this.filter}
-          />
           <ScrollSpy>
             { this.renderMenu() }
           </ScrollSpy>


### PR DESCRIPTION
# What
When user has no endpoints we should hide documentation view form app layout. We're going to have playground project for user to educate him about our project.

<img width="465" alt="zrzut ekranu 2017-06-05 13 24 59" src="https://cloud.githubusercontent.com/assets/1729299/26782159/786619ba-49f2-11e7-9efc-9ddf2bb4359a.png">
