### PR TITLE
[TUT-346] Fix json editor cancel button

### DIFF
--- a/app/client/components/JSONEditor/JSONEditor.js
+++ b/app/client/components/JSONEditor/JSONEditor.js
@@ -138,6 +138,7 @@ class JSONEditor extends React.Component {
   render() {
     const { editorState, jsonIsValid, isDirty, editMode, submitting } = this.state;
     const lines = editorState.getCurrentContent().getBlocksAsArray();
+    const showCancel = isDirty || !isEmpty(this.props.base);
 
     return (
       <div>
@@ -181,7 +182,9 @@ class JSONEditor extends React.Component {
               { isDirty &&
                 <Button onClick={this.onSave} disabled={!jsonIsValid} variants={['primary', 'large', 'spaceRight']}>Save</Button>
               }
-              <Button onClick={this.onCancel} variants={['body', 'large']}>Cancel</Button>
+              { showCancel &&
+                <Button onClick={this.onCancel} variants={['body', 'large']}>Cancel</Button>
+              }
             </div>
           )
         }


### PR DESCRIPTION
# What
When visiting request/response having both "body" and "body_draft" nil, json editor redirected directly to edit mode. It displayed "cancel" button at the bottom even if there was nothing to discard.

I've changed it so when body is empty we don't display cancel button as there's no way back to "preview" mode

# How to test
I've used http://localhost:3000/t-m-r/editor/endpoint/194/request for testing