### PR TITLE
[TUT-400] Remove project base url from new project wizard

### DIFF
--- a/app/client/components/Documentation/EndpointDoc.js
+++ b/app/client/components/Documentation/EndpointDoc.js
@@ -32,7 +32,7 @@ const showEndpointDocs = ({ topLevel, projectUrl, doc, projectSlug }) => (
         <div className={styles.section}>
           <Heading>HTTP Request</Heading>
           <Well variants={['body', 'bold', 'noPadding']}>
-            <span className={styles.method}>{doc.method}</span> {`${projectUrl}${doc.url}`}
+            <span className={styles.method}>{doc.method}</span> {`${projectUrl || ''}${doc.url}`}
           </Well>
         </div>
 

--- a/app/client/components/ProjectForm/NewProjectForm.js
+++ b/app/client/components/ProjectForm/NewProjectForm.js
@@ -29,14 +29,6 @@ let NewProjectForm = (props) => {
           placeholder="e.g. My Home API"
         />
       </InputGroup>
-      <InputGroup title="Base URL" variants={['smallLabel']}>
-        <Field
-          name="base_url"
-          component={RFTextInput}
-          placeholder="http://example.com"
-          type="url"
-        />
-      </InputGroup>
       <Button
         type="submit"
         variants={['primary', 'large', 'block']}

--- a/app/client/services/helpers.js
+++ b/app/client/services/helpers.js
@@ -1,5 +1,5 @@
 export function getFullLink(domain, endpoint) {
-  const basePath = `${domain}${endpoint.url}`;
+  const basePath = `${domain || ''}${endpoint.url}`;
 
   if (endpoint.params) {
     const mainParam = endpoint.url_params.find(p => p.is_part_of_url);


### PR DESCRIPTION
This removes input as well as handles projects without base url (in documentation and editor view)
<img width="414" alt="zrzut ekranu 2017-06-19 15 54 12" src="https://user-images.githubusercontent.com/1729299/27288648-a42f7f1c-5507-11e7-9274-070dc62c3a85.png">
