### PR TITLE
[TUT-387] Fix creating response error

### DIFF
--- a/app/client/utils/main-dist.js
+++ b/app/client/utils/main-dist.js
@@ -24,7 +24,6 @@ export class Main extends React.Component {
       <Provider store={store}>
         <div>
           <Router history={history} routes={getRoutes(store)} />
-          <Modals />
         </div>
       </Provider>
     );


### PR DESCRIPTION

# Explain why this change is being made
When user tried to submit a new response in Endpoint Editor
We were pulling endpoint_id from params. Unfortunately we've had
two instances of <Modals /> component in production. And the second one
did not have props set.

This was a mistake as we shouldn't have <Modals /> added twice. But this bug
was unnoticed because both modals were displaying at top of another.

# Links to any relevant tickets
https://exlabs.atlassian.net/browse/TUT-386