### PR TITLE
TUT-408 Remove endpoint that are not ready for documentation

### DIFF
--- a/app/client/containers/EndpointEditor/EndpointEditor.js
+++ b/app/client/containers/EndpointEditor/EndpointEditor.js
@@ -11,6 +11,8 @@ import {
   removeResponse,
 } from 'services/endpointEditor';
 
+import { endpointReadyForDocumentation } from 'services/documentation';
+
 import Button from 'components/Button/Button';
 import Header from 'components/Header/Header';
 
@@ -222,6 +224,14 @@ class EndpointEditor extends React.Component {
     }
   }
 
+  notDocumentationReadyWarning = () => (
+    <Notice
+      type="warning"
+      icon="eye-slash"
+      message="This endpoint will not appear in the documentation. Add at least one success response to make it visible."
+    />
+  )
+
   render() {
     const { endpoint } = this.props;
 
@@ -238,6 +248,9 @@ class EndpointEditor extends React.Component {
         { endpoint.status === 'outdated' && (
           <Notice type="warning" icon="chain-broken" message="This endpoint is outdated. This means one of responses, url params or request is no longer up to date with data received from your app" />
         )}
+        { !endpointReadyForDocumentation(endpoint)
+          && this.notDocumentationReadyWarning()
+        }
         <div className={styles.urlContainer} id="endpoint-editor-method">
           <div className={styles.method}>
             { endpoint && endpoint.method}

--- a/app/client/services/documentation.js
+++ b/app/client/services/documentation.js
@@ -79,7 +79,7 @@ function createEndpoint(item, parentGroup) {
   };
 }
 
-function endpointReadyForDocumentation(endpoint) {
+export function endpointReadyForDocumentation(endpoint) {
   return endpoint.responses
     && endpoint.responses.length > 0
     && endpoint.responses.some(response =>


### PR DESCRIPTION
I solved the problem by plugging a condition when building documentation tree.
I also added a warning message on endpoint editor (not sure about the copy):
![image](https://user-images.githubusercontent.com/1079965/27734720-77a6f112-5d9c-11e7-93b3-ea3a3115689d.png)
