### PR TITLE
TUT-409: [BUGFIX] Scroll editor to top after changing endpoints.

### DIFF
--- a/app/client/containers/Editor/Editor.js
+++ b/app/client/containers/Editor/Editor.js
@@ -30,11 +30,17 @@ class Editor extends React.Component {
   }
 
   componentDidMount() {
+    this.container.scrollIntoView();
     openFirstEndpointIfNeeded(this.props);
   }
 
   componentWillReceiveProps(nextProps) {
-    this.container.scrollIntoView();
+    const { endpoint_id } = this.props.params;
+
+    if (nextProps.params.endpoint_id !== endpoint_id) {
+      this.container.scrollIntoView();
+    }
+
     openFirstEndpointIfNeeded(nextProps);
   }
 


### PR DESCRIPTION
On change props (page load or change of endpoint) scroll element to top.